### PR TITLE
Concert shutdown

### DIFF
--- a/concert_conductor/package.xml
+++ b/concert_conductor/package.xml
@@ -20,6 +20,7 @@
   <run_depend>rocon_app_manager_msgs</run_depend>
   <run_depend>concert_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>gateway_msgs</run_depend>
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -44,6 +44,7 @@
     <include file="$(find rocon_hub)/launch/hub.launch">
       <arg name="hub_name" value="$(arg concert_name)" />
       <arg name="hub_port" value="6380" />
+      <arg name="external_shutdown" value="true"/> <!-- let the conductor shut it down -->
     </include>
 
     <!-- ******************************** Gateway ******************************** -->
@@ -56,6 +57,7 @@
       <param name="watch_loop_period" value="$(arg gateway_watch_loop_period)"/>
       <param name="hub_whitelist" value="$(arg concert_hub_uri)"/>
       <param name="disable_uuids" value="$(arg disable_uuids)"/>
+      <param name="external_shutdown" value="true"/> <!-- let the conductor shut it down -->
     </node>
     <!-- ****************************** Zeroconf ******************************* -->
     <node ns="zeroconf" pkg="zeroconf_avahi" type="zeroconf" name="zeroconf">

--- a/concert_service_manager/package.xml
+++ b/concert_service_manager/package.xml
@@ -9,7 +9,7 @@
   <url type="website">http://www.ros.org/wiki/concert_service_manager</url>
   <url type="repository">https://github.com/robotics-in-concert/rocon_concert</url>
   <url type="bugtracker">https://github.com/robotics-in-concert/rocon_concert/issues</url>
-  <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
+  <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <author email="jihoonlee.in@gmail.com">Jihoon Lee</author>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/concert_service_manager/package.xml
+++ b/concert_service_manager/package.xml
@@ -17,6 +17,6 @@
   <run_depend>concert_msgs</run_depend>
   <run_depend>concert_roles</run_depend>
   <run_depend>genpy</run_depend>
-  <run_depend>rospkg</run_depend>
+  <run_depend>python-rospkg</run_depend>
 
 </package>

--- a/concert_service_manager/src/concert_service_manager/concert_service_instance.py
+++ b/concert_service_manager/src/concert_service_manager/concert_service_instance.py
@@ -166,7 +166,6 @@ class ConcertServiceInstance(object):
 
     def _start_roslaunch(self):
         try:
-            rospy.logwarn("Start roslaunch")
             force_screen = True
             roslaunch_file_path = rocon_utilities.find_resource_from_string(self._description.launcher, extension='launch')
             temp = tempfile.NamedTemporaryFile(mode='w+t', delete=False)


### PR DESCRIPTION
For #121 and #123. External shutdown hooks into the gateway and hub so the conductor can delay their respective shutdowns.

This is introduced as a non-default behaviour, especially for concerts.

Note: bloody signal handling for subprocesses of a rospy node is a huge pain in the ass.
