### PR TITLE
Releasing requests when enabling/disabling a service

### DIFF
--- a/concert_schedulers/scripts/compatibility_tree_scheduler.py
+++ b/concert_schedulers/scripts/compatibility_tree_scheduler.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     rospy.init_node('scheduler')
     # If we use the changes only and something goes wrong in allocation, then scheduler needs code to repeat the attempt (currently nothing like this)
     # scheduler = concert_schedulers.CompatibilityTreeScheduler(concert_msgs.Strings.CONCERT_CLIENT_CHANGES, concert_msgs.Strings.SCHEDULER_REQUESTS)
-    # If we use the periodic publisher, then we can use those interrupts as the loop to do continuous checking (but we need to optimise processing better).
+    # If we use the periodic publisher, then we can use those interrupts as the loop to do continuous checking but it might be
+    # an idea to optimise this better so it isn't continually processing
     scheduler = concert_schedulers.CompatibilityTreeScheduler(concert_msgs.Strings.CONCERT_CLIENTS, concert_msgs.Strings.SCHEDULER_REQUESTS)
     scheduler.spin()

--- a/concert_schedulers/src/concert_schedulers/resource_pool_requester/requester.py
+++ b/concert_schedulers/src/concert_schedulers/resource_pool_requester/requester.py
@@ -66,6 +66,13 @@ class ResourcePoolRequester():
         self._initial_request_uuid = self._requester.new_request(initial_resources, priority=self._high_priority)
 
     def _requester_feedback(self, request_set):
+        '''
+          This returns requests processed by the scheduler with whatever necessary modifications
+          that were made on the original requests.
+
+          @param request_set : the modified requests
+          @type dic { uuid.UUID : scheduler_msgs.ResourceRequest }
+        '''
         # call self._feedback in here
         #print("Request set: %s" % request_set)
         # should we reset all tracking, allocated flags in all resources here, then enable them below?
@@ -73,7 +80,7 @@ class ResourcePoolRequester():
             resource_group.reset_scheduler_flags()
         for request in request_set.values():
             high_priority_flag = True if request.msg.priority == self._high_priority else False
-            if request.msg.status == scheduler_msgs.Request.NEW:
+            if request.msg.status == scheduler_msgs.Request.NEW or request.msg.status == scheduler_msgs.Request.WAITING:
                 self._flag_resource_trackers(request.msg.resources, tracking=True, allocated=False, high_priority_flag=high_priority_flag)
             elif request.msg.status == scheduler_msgs.Request.GRANTED:
                 self._flag_resource_trackers(request.msg.resources, tracking=True, allocated=True, high_priority_flag=high_priority_flag)

--- a/concert_schedulers/src/concert_schedulers/resource_pool_requester/requester.py
+++ b/concert_schedulers/src/concert_schedulers/resource_pool_requester/requester.py
@@ -7,10 +7,12 @@
 # Imports
 ##############################################################################
 
+import copy
 import rospy
 import unique_id
 import rocon_scheduler_requests
 import scheduler_msgs.msg as scheduler_msgs
+import threading
 
 ##############################################################################
 # Methods
@@ -38,7 +40,9 @@ class ResourcePoolRequester():
             '_high_priority',
             '_low_priority',
             '_initial_request_uuid',
-            'alive'
+            'alive',
+            '_request_set',
+            '_lock'
         ]
 
     def __init__(self,
@@ -59,11 +63,27 @@ class ResourcePoolRequester():
         self._alive = False
         self._high_priority = high_priority
         self._low_priority = low_priority
+        self._request_set = None
+        self._lock = threading.Lock()
 
         initial_resources = []
         for resource_group in self._resource_groups:
             initial_resources.extend(resource_group.initial_resources())
         self._initial_request_uuid = self._requester.new_request(initial_resources, priority=self._high_priority)
+
+    def cancel_all_requests(self):
+        '''
+          Exactly as it says! Used typically when shutting down.
+
+          Note - called by external processes, so make sure it's protected.
+        '''
+        self._lock.acquire()
+        for request in self._request_set.values():
+            if request.msg.status == scheduler_msgs.Request.GRANTED:
+                request.release()
+        self._requester.rset.merge(self._request_set)
+        self._requester.send_requests()
+        self._lock.release()
 
     def _requester_feedback(self, request_set):
         '''
@@ -73,6 +93,9 @@ class ResourcePoolRequester():
           @param request_set : the modified requests
           @type dic { uuid.UUID : scheduler_msgs.ResourceRequest }
         '''
+        self._lock.acquire()
+        self._request_set = copy.deepcopy(request_set)
+        self._lock.release()
         # call self._feedback in here
         #print("Request set: %s" % request_set)
         # should we reset all tracking, allocated flags in all resources here, then enable them below?
@@ -110,6 +133,11 @@ class ResourcePoolRequester():
                     unused_request_uuid = self._requester.new_request([resource], priority=priority)
 
     def _flag_resource_trackers(self, resources, tracking, allocated, high_priority_flag):
+        '''
+          Update the flags in the resource trackers for each resource. This is used to
+          follow whether a particular resource is getting tracked, or is already allocated so
+          that we can determine if new requests should be made and at what priority.
+        '''
         for resource in resources:
             resource_tracker = self._find_resource_tracker(unique_id.toHexString(resource.id))
             if resource_tracker is None:

--- a/concert_service_manager/package.xml
+++ b/concert_service_manager/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>concert_msgs</run_depend>
   <run_depend>concert_roles</run_depend>
   <run_depend>genpy</run_depend>

--- a/concert_service_manager/setup.py
+++ b/concert_service_manager/setup.py
@@ -5,7 +5,12 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
     packages=['concert_service_manager'],
-    package_dir={'':'src'}
+    package_dir={'':'src'},
+    requires=['rospy',
+              'std_msgs',
+              'concert_msgs',
+              'concert_roles'
+             ]
 )
 
 setup(**d)

--- a/concert_service_manager/src/concert_service_manager/concert_service_instance.py
+++ b/concert_service_manager/src/concert_service_manager/concert_service_instance.py
@@ -53,7 +53,7 @@ class ConcertServiceInstance(object):
         self._lock = threading.Lock()
         self._proc = None
         self._roslaunch = None
-        self._shutdown_publisher = rospy.Publisher(self._namespace + "/shutdown", std_msgs.Empty, latch=True)
+        self._shutdown_publisher = rospy.Publisher(self._namespace + "/shutdown", std_msgs.Empty, latch=False)
 
     def __del__(self):
         if self._proc is not None:
@@ -125,7 +125,7 @@ class ConcertServiceInstance(object):
                         break
                     count = count + 1
             elif launcher_type == concert_msgs.ConcertService.TYPE_ROSLAUNCH:
-                rospy.loginfo("shutting down roslaunched concert service [%s]" % self._description.name)
+                rospy.loginfo("Service Manager : shutting down roslaunched concert service [%s]" % self._description.name)
                 count = 0
                 # give it some time to naturally die first.
                 while self._roslaunch.pm and not self._roslaunch.pm.done:

--- a/concert_service_roslaunch/package.xml
+++ b/concert_service_roslaunch/package.xml
@@ -14,6 +14,7 @@
   <run_depend>rocon_std_msgs</run_depend>
   <run_depend>concert_msgs</run_depend>
   <run_depend>unique_id</run_depend>
+  <run_depend>std_msgs</run_depend>
   <run_depend>uuid_msgs</run_depend>
   <run_depend>scheduler_msgs</run_depend>
   <run_depend>rocon_scheduler_requests</run_depend>

--- a/concert_service_roslaunch/setup.py
+++ b/concert_service_roslaunch/setup.py
@@ -8,6 +8,7 @@ d = generate_distutils_setup(
     package_dir={'':'src'},
     requires=['rospy', 
               'unique_id',
+              'std_msgs',
               'uuid_msgs',
               'concert_msgs',
               'rocon_std_msgs',

--- a/concert_service_roslaunch/src/concert_service_roslaunch/static_link_graph_handler.py
+++ b/concert_service_roslaunch/src/concert_service_roslaunch/static_link_graph_handler.py
@@ -92,11 +92,12 @@ class StaticLinkGraphHandler(object):
             self._requester.cancel_all_requests()
         else:
             # we don't have a function stub, have to implement it here ourselves.
-            for request in self._requester.rset:
-                if request.msg.status == scheduler_msgs.Request.GRANTED:
-                    request.release()
+            for request in self._requester.rset.values():
+                # This is actually a hack because we don't use the real scheduler on the other
+                # side, we just publish these messages. The other scheduler is our demo
+                # scheduler, which will be aware of checking for the releasing flag.
+                request.msg.status = scheduler_msgs.Request.RELEASING
             self._requester.send_requests()
-            rospy.logwarn("Service : this is a stub for catching a shutdown signal - we have to deallocate resources here.")
         self._disabled = True
 
     def _setup_resource_pool_requester(self):


### PR DESCRIPTION
Currently for demo scheduler only. Part of the infra built up the transition logic for the resource pool requester, but hasn't been implemented on the compatibility tree scheduler yet.
