### PR TITLE
Enable preemption as an option in the compatibility tree scheduler.

### DIFF
--- a/concert_conductor/src/concert_conductor/concert_clients.py
+++ b/concert_conductor/src/concert_conductor/concert_clients.py
@@ -327,7 +327,6 @@ class ConcertClients(object):
                                   )
                 if response.result:
                     self._transition(concert_client, State.JOINING)()
-                    self._local_gateway.request_pulls(remote_gateway.name, cancel=True, service_names=['invite'], topic_names=[])
                     return True
                 else:
                     rospy.logwarn("Conductor : failed to invite client [%s][%s]" % (response.message, concert_client.gateway_name))
@@ -338,6 +337,7 @@ class ConcertClients(object):
                        ):
                         rospy.logwarn("Conductor : invitation to %s was blocked [%s][%s]" % (concert_client.gateway_name, response.message, concert_client.gateway_name))
                         self._transition(concert_client, State.BLOCKING)()
+                        self._local_gateway.request_pulls(remote_gateway.name, cancel=True, service_names=['invite'], topic_names=[])
                     elif response.error_code == rocon_app_manager_msgs.ErrorCodes.ALREADY_REMOTE_CONTROLLED:
                         rospy.logwarn("Conductor : invitation to %s was refused [%s][%s]" % (concert_client.gateway_name, response.message, concert_client.gateway_name))
                         self._transition(concert_client, State.BUSY)()
@@ -345,7 +345,7 @@ class ConcertClients(object):
                         rospy.logwarn("Conductor : invitation to %s failed [%s][%s]" % (concert_client.gateway_name, response.message, concert_client.gateway_name))
                         self._transition(concert_client, State.BAD)()
                         self._clients_by_state[State.BAD][remote_gateway.name] = concert_client
-                    self._local_gateway.request_pulls(remote_gateway.name, cancel=True, service_names=['invite'], topic_names=[])
+                        self._local_gateway.request_pulls(remote_gateway.name, cancel=True, service_names=['invite'], topic_names=[])
                     return True
             except rospy.ServiceException:
                 rospy.logwarn("Conductor : invitation to %s was sent, but not received [service exception][%s]" % (concert_client.concert_alias, concert_client.gateway_name))

--- a/concert_conductor/src/concert_conductor/transitions.py
+++ b/concert_conductor/src/concert_conductor/transitions.py
@@ -35,6 +35,25 @@ class Dummy(object):
         pass
 
 
+class TransitionToGone(object):
+    """
+    Transition handler when moving from any state to the gone state. This will always
+    occur if the remote gateway has disappeared from the hub's awareness (happens
+    when the remote gateway shuts down) or has been missing too long. We manually
+    update the fact that the gateway is no longer available in the concert client's
+    data here.
+    """
+
+    def __init__(self, concert_client):
+        self.concert_client = concert_client
+
+    def __call__(self):
+        """
+        Nothing to do here.
+        """
+        self.concert_client.msg.conn_stats.gateway_available = False
+
+
 class PendingToUninvited(object):
     """
     Triggered when information about this client has been gathered.
@@ -75,13 +94,13 @@ StateTransitionTable = {
     (State.PENDING, State.BLOCKING)  : Dummy,
     (State.PENDING, State.BUSY)      : Dummy,
     (State.PENDING, State.UNINVITED) : PendingToUninvited,
-    (State.PENDING, State.GONE)      : Dummy,
+    (State.PENDING, State.GONE)      : TransitionToGone,
 
     (State.UNINVITED, State.BAD)      : Dummy,
     (State.UNINVITED, State.BLOCKING) : Dummy,
     (State.UNINVITED, State.BUSY)     : Dummy,
     (State.UNINVITED, State.JOINING)  : Dummy,
-    (State.UNINVITED, State.GONE)     : Dummy,
+    (State.UNINVITED, State.GONE)     : TransitionToGone,
 
     (State.JOINING, State.BAD)        : Dummy,
     (State.JOINING, State.AVAILABLE)  : Dummy,
@@ -90,15 +109,15 @@ StateTransitionTable = {
     (State.AVAILABLE, State.BAD)      : Dummy,
     (State.AVAILABLE, State.MISSING)  : AvailableToMissing,
     (State.AVAILABLE, State.UNINVITED): Dummy,
-    (State.AVAILABLE, State.GONE)     : Dummy,
+    (State.AVAILABLE, State.GONE)     : TransitionToGone,
 
     (State.MISSING, State.AVAILABLE)  : Dummy,
-    (State.MISSING, State.GONE)       : Dummy,
+    (State.MISSING, State.GONE)       : TransitionToGone,
 
     (State.BUSY, State.UNINVITED)     : Dummy,
-    (State.BUSY, State.GONE)          : Dummy,
+    (State.BUSY, State.GONE)          : TransitionToGone,
 
-    (State.BLOCKING, State.GONE)      : Dummy,
+    (State.BLOCKING, State.GONE)      : TransitionToGone,
 
-    (State.BAD, State.GONE)           : Dummy,
+    (State.BAD, State.GONE)           : TransitionToGone,
 }

--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -24,8 +24,9 @@
   <arg name="rosbridge_address" default="localhost"/>
   <arg name="rosbridge_port" default="9090"/>
   <!--                  Schedulers
-      - compatibility_tree : concert_schedulers/compatibility_tree_scheduler.launch
-      - simple             : concert_schedulers/simple_scheduler.launch
+      - preemptive_compatibility_tree : concert_schedulers/preemptive_compatibility_tree_scheduler.launch
+      - compatibility_tree            : concert_schedulers/compatibility_tree_scheduler.launch
+      - simple                        : concert_schedulers/simple_scheduler.launch
    -->
   <arg name="scheduler_type" default="compatibility_tree"/>
 

--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -72,11 +72,11 @@
     <node pkg="rocon_gateway" type="gateway.py" name="gateway">
       <rosparam command="load" file="$(find rocon_gateway)/param/default.yaml"/>
       <rosparam command="load" file="$(find rocon_gateway)/param/default_blacklist.yaml"/>
+      <rosparam param="hub_whitelist" subst_value="True">["$(arg hub_uri)"]</rosparam>
       <param name="hub_uri" value="$(arg hub_uri)"/>
       <param name="name" value="$(arg concert_name)"/>
       <param name="firewall" value="false"/>
       <param name="watch_loop_period" value="$(arg gateway_watch_loop_period)"/>
-      <param name="hub_whitelist" value="$(arg hub_uri)"/>
       <param name="disable_uuids" value="$(arg gateway_disable_uuids)"/>
       <param name="network_interface" value="$(arg gateway_network_interface)"/>
       <param name="external_shutdown" value="true"/> <!-- let the conductor shut this node down -->

--- a/concert_schedulers/.project
+++ b/concert_schedulers/.project
@@ -3,6 +3,7 @@
 	<name>concert_schedulers</name>
 	<comment></comment>
 	<projects>
+		<project>concert_scheduler_requests</project>
 		<project>rocon_console</project>
 		<project>rocon_uri</project>
 		<project>unique_id</project>

--- a/concert_schedulers/launch/preemptive_compatibility_tree_scheduler.launch
+++ b/concert_schedulers/launch/preemptive_compatibility_tree_scheduler.launch
@@ -1,5 +1,5 @@
 <launch>
   <node pkg="concert_schedulers" name="scheduler" type="compatibility_tree_scheduler.py">
-    <param name="enable_preemptions" value="false"/>
+    <param name="enable_preemptions" value="true"/>
   </node>
 </launch>

--- a/concert_schedulers/src/concert_schedulers/compatibility_tree_scheduler/ros_parameters.py
+++ b/concert_schedulers/src/concert_schedulers/compatibility_tree_scheduler/ros_parameters.py
@@ -1,0 +1,24 @@
+#
+# License: BSD
+#   https://raw.github.com/robotics-in-concert/rocon_app_platform/license/LICENSE
+#
+##############################################################################
+# Imports
+##############################################################################
+
+import rospy
+
+###############################################################################
+# Functions
+###############################################################################
+
+
+def setup_ros_parameters():
+    '''
+      Returns validated parameters for this module from the ros param server.
+    '''
+    param = {}
+    param['debug_show_compatibility_tree'] = rospy.get_param('~debug_show_compatibility_tree', True)
+    param['enable_preemptions'] = rospy.get_param('~enable_preemptions', True)
+
+    return param

--- a/concert_schedulers/src/concert_schedulers/compatibility_tree_scheduler/scheduler.py
+++ b/concert_schedulers/src/concert_schedulers/compatibility_tree_scheduler/scheduler.py
@@ -304,12 +304,12 @@ class CompatibilityTreeScheduler(object):
         # Releasing
         ########################################
         for reply in releasing_replies:
-            rospy.loginfo("Scheduler : releasing resources from cancelled request [%s]" % (reply.msg.resources))
-            #print("Releasing Resources: %s" % [r.rapp for r in reply.msg.resources])
-            #print("  Releasing Resources: %s" % [r.uri for r in reply.msg.resources])
-            #print("  Clients: %s" % self._clients.keys())
-            #for client in self._clients.values():
-            #    print(str(client))
+            if reply.msg.reason == scheduler_msgs.Request.NONE:
+                rospy.loginfo("Scheduler : releasing resources from cancelled request [%s][none]" % ([resource.rapp for resource in reply.msg.resources]))
+            elif reply.msg.reason == scheduler_msgs.Request.TIMEOUT:
+                rospy.loginfo("Scheduler : releasing resources from cancelled request [%s][scheduler-requester watchdog timeout]" % ([resource.rapp for resource in reply.msg.resources]))
+            else:
+                rospy.loginfo("Scheduler : releasing resources from cancelled request [%s][%s]" % ([resource.rapp for resource in reply.msg.resources], reply.msg.reason))
             for resource in reply.msg.resources:
                 try:
                     self._clients[rocon_uri.parse(resource.uri).name.string].abandon()


### PR DESCRIPTION
This enables it in the concert via a new scheduler type. The default is the same as before - compatibility_tree_scheduler, but it's behaviour is now different.
- compatibility_tree : now no longer supports preemption
- preemptive_compatibility_tree : now no longer supports preemption
- simple_scheduler : jacks (has no preemption).

Pull this in at the same time as https://github.com/robotics-in-concert/rocon_tutorials
