### PR TITLE
Patch load_parameter in service manager util

### DIFF
--- a/concert_service_manager/src/concert_service_manager/load_params.py
+++ b/concert_service_manager/src/concert_service_manager/load_params.py
@@ -42,7 +42,7 @@ def load_parameter(key, value, namespace, name, load):
         if load:
             try:
                 rospy.set_param(param_name, eval(value))
-            except (NameError, TypeError):
+            except (NameError, TypeError, SyntaxError):
                 rospy.set_param(param_name, value)
         else:
             rospy.delete_param(param_name)


### PR DESCRIPTION
If parameter value is include special symbol(for example `/`, `\` and so on.) syntax error is happened. 
https://github.com/robotics-in-concert/rocon_concert/issues/273
