### PR TITLE
passing parameter to the interaction manager

### DIFF
--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -76,6 +76,7 @@
       <param name="rosbridge_address" value="$(arg rosbridge_address)"/>
       <param name="rosbridge_port" value="$(arg rosbridge_port)"/>
       <param name="webserver_address" value="$(arg webserver_address)"/>
+      <param name="rapp_manager" value="false"/>
     </node>
 
     <!-- ******************************** Hub ********************************** -->


### PR DESCRIPTION
to prevent looking for rapp_manager on concert master.

Maybe there is a better/cleaner way to do this ? Like using the is_pairing parameter instead of making a new one...
